### PR TITLE
Added support for hiding the status bar

### DIFF
--- a/BDBSplitViewController/BDBSplitViewController.h
+++ b/BDBSplitViewController/BDBSplitViewController.h
@@ -143,6 +143,12 @@ typedef NS_ENUM(NSInteger, BDBSplitViewControllerMasterDisplayStyle) {
 
 @property (nonatomic) UIStatusBarStyle preferredStatusBarStyle;
 
+/**
+ * Set this flag to hide or show the status bar.
+ * Don't forget to call setNeedsStatusBarAppearanceUpdate after changing this flag.
+ **/
+@property (nonatomic) BOOL statusBarHidden;
+
 #pragma mark Initialization
 /**
  *  Create and initialize a split view with the given master and detail view controllers.

--- a/BDBSplitViewController/BDBSplitViewController.m
+++ b/BDBSplitViewController/BDBSplitViewController.m
@@ -164,6 +164,11 @@ static NSString * const kBDBSplitViewControllerKVOKeyPath = @"view.frame";
     [self willRotateToInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation] duration:0.f];
 }
 
+- (BOOL)prefersStatusBarHidden
+{
+    return self.statusBarHidden;
+}
+
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];

--- a/BDBSplitViewController/BDBSplitViewController.m
+++ b/BDBSplitViewController/BDBSplitViewController.m
@@ -281,7 +281,7 @@ static NSString * const kBDBSplitViewControllerKVOKeyPath = @"view.frame";
                                               @"Show/Hide button title when master view is visible.");
 
         _showHideMasterViewButtonItem = [[UIBarButtonItem alloc] initWithTitle:buttonTitle
-                                                                         style:UIBarButtonItemStyleBordered
+                                                                         style:UIBarButtonItemStylePlain
                                                                         target:self
                                                                         action:@selector(toggleMasterView:)];
     }
@@ -298,7 +298,7 @@ static NSString * const kBDBSplitViewControllerKVOKeyPath = @"view.frame";
                                                                                      [NSBundle mainBundle],
                                                                                      @"Close",
                                                                                      @"Close button title.")
-                                             style:UIBarButtonItemStyleBordered
+                                             style:UIBarButtonItemStylePlain
                                             target:self
                                             action:@selector(closeMasterView:)];
     }


### PR DESCRIPTION
I want to be able to display the detailViewController in fullscreen, so I added a new property "statusBarHidden" to BDBSplitViewController. Default value is NO, of course. 
